### PR TITLE
add total frustration functions and an example notebook

### DIFF
--- a/examples/DCA_frustration_example.ipynb
+++ b/examples/DCA_frustration_example.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "6110e6f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "90da9088",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,6 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "01117f26",
    "metadata": {},
    "outputs": [
     {
@@ -58,6 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "f72eaa30",
    "metadata": {},
    "outputs": [
     {
@@ -78,6 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "c615ce2f",
    "metadata": {},
    "outputs": [
     {
@@ -100,6 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "8b2d09c7",
    "metadata": {},
    "outputs": [
     {
@@ -117,6 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "058d99cb",
    "metadata": {},
    "outputs": [
     {
@@ -149,6 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "306d5a77",
    "metadata": {},
    "outputs": [
     {
@@ -189,6 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "c1d8bb8a",
    "metadata": {},
    "outputs": [
     {
@@ -221,6 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "f07366bd",
    "metadata": {},
    "outputs": [
     {
@@ -253,6 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "1b1ca83e",
    "metadata": {},
    "outputs": [
     {
@@ -285,9 +296,8 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "scrolled": false
-   },
+   "id": "7653f7e0",
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -319,6 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "9bf56985",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,6 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "276eb742",
    "metadata": {},
    "outputs": [
     {
@@ -348,6 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "c35a2844",
    "metadata": {},
    "outputs": [
     {
@@ -368,6 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "e71e06e7",
    "metadata": {},
    "outputs": [
     {
@@ -388,6 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
+   "id": "9e25ad28",
    "metadata": {},
    "outputs": [
     {
@@ -3844,7 +3859,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -3858,7 +3873,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.11.4"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/view_pdb_dca_frustration.ipynb
+++ b/examples/view_pdb_dca_frustration.ipynb
@@ -374,7 +374,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/frustratometer/classes/Frustratometer.py
+++ b/frustratometer/classes/Frustratometer.py
@@ -499,5 +499,54 @@ class Frustratometer:
         neutral_gr=np.divide(neutral_hist,(shell_vol*neutral_density))
         
         return minimally_frustrated_gr,frustrated_gr,neutral_gr,r_m
+   
+
+    def total_frustration(self,
+                      n_decoys: int = 1000,
+                      config_decoys: bool = False,
+                      msa_mask: Union[int, np.array] = 1,
+                      fragment_pos: Union[None, np.array] = None,
+                      fragment_in_context: bool = False,
+                      output_kind: str = 'frustration') -> Union[float, np.array] :
+
+        """
+        Calculates the total frustration of a protein fragment.
+
+        Parameters
+        ----------
+        n_decoys: int
+            Number of sequence decoys to create
+        config_decoys: bool
+            To use configurational frustration approximation
+        msa_mask: np.array
+            Extra mask to use a Multiple Sequence Alignment that do not cover completely the reference PDB
+        fragment_pos: np.array
+            Fragment positions. If None, use the complete model
+        fragment_in_context: bool
+            If True, the energetics calculations take into account the interactions between the fragment and other sequence positions
+        output_kind: str
+            If 'frustration', returns frustration. If not, returns native energy, decoy energy average and decoy energy standard deviation.
+        Return
+        -------
+        total_frustration : float
+            Total frustration of the fragment or complete protein
+        native_energy: float
+            Native energy of the given sequence
+        decoy_energy_average: float
+            Average of the decoy energy distribution
+        decoy_energy_std: float
+            Standard deviation of the decoy energy distribution
+        """
+
+        return frustration.compute_total_frustration(self.sequence,
+                                                     self.potts_model,
+                                                     self.mask,
+                                                     n_decoys,
+                                                     config_decoys,
+                                                     msa_mask,
+                                                     fragment_pos,
+                                                     fragment_in_context,
+                                                     output_kind)
+
 
 

--- a/frustratometer/frustration/__init__.py
+++ b/frustratometer/frustration/__init__.py
@@ -14,4 +14,5 @@ __all__ = ['compute_mask', 'compute_native_energy', 'compute_fields_energy', 'co
            'compute_contact_decoy_energy_fluctuation', 'compute_decoy_energy', 'compute_aa_freq',
            'compute_contact_freq', 'compute_single_frustration', 'compute_pair_frustration', 'compute_scores',
            'compute_roc', 'compute_auc', 'plot_roc', 'plot_singleresidue_decoy_energy', 'write_tcl_script',
-           'call_vmd', 'canvas']
+           'call_vmd', 'canvas', 'make_decoy_seqs','compute_fragment_mask', 'compute_fragment_total_native_energy', 'compute_fragment_total_decoy_energy',
+          'compute_total_frustration']


### PR DESCRIPTION
## Description
I added functions at the end of the frustration.py file to compute energy using the proper masks for segments "in context". I also included a function to compute total frustration. For the  frustration of an "independent" fragment, the total frustration should be computed using a sliced pdb model using only that fragment.

The new functions use explicit decoy computation. Sequence decoys are created using the lenght and amino acid composition of the native sequence, and their energy is computed directly. An "approximation" for the total configurational frustration is available also. 

I added the total frustration function to the Frustratometer class. 
I created a new example notebook to use these new functions

## Todos
  - [ ] Improve the description of the new functions in the frustration.py file
  - [ ] Add functions to compute the sliding window frustration (using the "in context" energy computation).

## Note
The total frustration that can be directly computed using this module is not directly comparable with the PNAS 2024 results for exon relative total frustration. For that, it should be taken into account that the sequences and potts models do not cover the complete PDBs and that the native sequences used were not PDB sequences, but instead the ones having the analyzed exon.